### PR TITLE
Migrate pure markdown pages

### DIFF
--- a/pages/accessibility.md
+++ b/pages/accessibility.md
@@ -1,0 +1,19 @@
+---
+title: Accessibility Statement
+---
+
+## Commitment
+
+We want core.ac.uk to be accessible to the widest audience possible, regardless of technology or ability. Thus, we are actively working to increase the accessibility and usability of this site.
+
+## Guidelines
+
+We follow the [Open University accessibility standards](https://www.open.ac.uk/about/digital-governance/digital-standards-and-guidelines/accessibility), based on [WCAG 2.1](https://www.w3.org/TR/WCAG20/#intro), where each point has been selected and rephrased for clarity and briefly explained. You can read about this in greater detail at the [Open University web standards pages](https://www.open.ac.uk/about/digital-governance/digital-standards-and-guidelines/accessibility).
+
+Where possible this site has been built using code compliant with W3C standards for HTML and CSS. The site should display correctly in current browsers on Windows, MacOS, Android and iOS.
+
+If you use a screen reader to access websites, you may find the following instructions useful: [access pdfs with a screen reader](https://www.open.ac.uk/about/main/strategy-and-policies/policies-and-statements/how-access-pdfs-screen-reader).
+
+## Exceptions and issues
+
+While we strive to be as accessible and usable as possible, errors and issues may occur. If you experience any difficulty in using this site then please [get in touch](~contact).

--- a/pages/acknowledge.md
+++ b/pages/acknowledge.md
@@ -1,0 +1,27 @@
+---
+title: How to acknowledge the use of CORE
+---
+
+If you use CORE in your work, you should acknowledge it as follows:
+
+1.  **In research papers:** provide an explicit citation to one or more of
+    our relevant research outputs. Please, do not just provide
+    a&nbsp;URL to&nbsp;CORE in a footnote.
+
+2.  **A website using/powered by CORE:** we expect an attribution at
+    the project’s main page by using [CORE’s logo][logo]
+    or the [powered by CORE][powered-by-banner].
+
+3.  **Where CORE feeds individual resources, e.g. research articles,
+    into a third party system:** provide a provenance link back to the
+    relevant CORE entity. We also encourage the use of
+    the [CORE’s logo][logo] or the [powered by CORE][powered-by-banner].
+
+You authorise us to use the logo of your project on our website and
+mentioning our support to you.
+
+We reserve the right to withdraw our approval for use of CORE at any time
+by giving you a 30-day notice.
+
+[logo]: /resources/core-logo.png
+[powered-by-banner]: /resources/powered-by-core-orange.png

--- a/pages/advantages-of-being-harvested.md
+++ b/pages/advantages-of-being-harvested.md
@@ -1,0 +1,183 @@
+---
+title: Advantages of joining CORE
+---
+
+## CORE serves Open Access
+
+CORE aggregates open access articles from data providers around the world. For
+the majority of data providers, we identify the oai base url of the repository
+from the Directory of Open Access Repositories, [OpenDOAR][open-doar].
+OpenDOAR is the primary registry of open access repositories and registration
+in OpenDOAR ensures that the harvested repositories host open access content.
+
+CORE’s mission to “aggregate all open access research outputs from
+repositories and journals worldwide and make them available to the public”
+aligns with the aims of the [Budapest Open Access Initiative][oa-initiative]
+to “accelerate research, enrich education … make the literature as useful as
+it can be.” Our process for aggregation of articles from repositories is fully
+compliant with the original [BOAI definition of Open Access][oa-definition].
+
+> By "open access" to this literature, we mean its free availability on
+> the public internet, permitting any users to read, download, copy,
+> distribute, print, search, or link to the full texts of these articles,
+> crawl them for indexing, pass them as data to software, or use them for
+> any other lawful purpose, without financial, legal, or technical
+> barriers other than those inseparable from gaining access to the
+> internet itself. The only constraint on reproduction and distribution,
+> and the only role for copyright in this domain, should be to give
+> authors control over the integrity of their work and the right to be
+> properly acknowledged and cited.
+>
+> <footer class="blockquote-footer">BOAI definition of Open Access</footer>
+
+[open-doar]: http://v2.sherpa.ac.uk/opendoar/
+[oa-initiative]: https://www.budapestopenaccessinitiative.org/boai-10-recommendations
+[oa-definition]: https://www.budapestopenaccessinitiative.org/read
+
+## CORE facilitates access to scientific research outputs for all
+
+CORE facilitates access to scientific research outputs both for readers and
+machines.
+
+While even the wealthiest universities in the world [cannot
+afford][harvard-cannot-afford] journal subscriptions, CORE is working towards
+serving both the haves and have-nots. By providing seamless access to millions
+of open access research papers to everyone for free via its [Search
+engine](/), CORE saves users valuable time in searching for open
+access scientific literature.
+
+CORE collects, processes, harmonises and enriches large quantities of metadata
+and full texts, providing a unique [API](~services/api) offering real-time
+machine access to both metadata and full text. At the same time, CORE data can
+be downloaded as a bulk dataset, via the [CORE Dataset](~services/dataset),
+enabling their processing in one’s own computer or infrastructure.
+
+[harvard-cannot-afford]: https://www.theguardian.com/science/2012/apr/24/harvard-university-journal-publishers-prices#:~:text=A%20memo%20from%20Harvard%20Library,library%20around%20%243.5m%20a%20year.
+
+## CORE enriches global open access literature
+
+Overall, the main role of aggregators is to fulfil and support scholarly use
+cases, which cannot be satisfied by individual repositories and contribute to
+the open access mission.
+
+According to the Confederation of Open Access Repositories (COAR)
+[report][coar-report]:
+
+> A single scientific repository is of limited value, real benefits come from
+> the ability to exchange data within a network … interoperability allows us to
+> exploit today's computational power so that we can aggregate, data mine,
+> create new tools and services, and generate new knowledge from repository
+> content.
+
+
+The Next Generation Repositories Working Group of COAR also
+[advocates][nextgen-repos] for repositories to provide better support for full
+text harvesting and support use cases enabled by it, including those based on
+text and data mining of repositories’ content.
+
+Additionally, SPARC’s position paper on the role of repositories specifically
+says:
+
+> For the repository to provide access to the broader research community,
+> users outside the university must be able to find and retrieve
+> information from the repository. Therefore, institutional repository
+> systems must be able to support interoperability in order to provide
+> access via multiple search engines and other discovery tools. An
+> institution does not necessarily need to implement searching and
+> indexing functionality to satisfy this demand: it could simply maintain
+> and expose metadata, allowing other services to harvest and search the
+> content. This simplicity lowers the barrier to repository operation for
+> many institutions, as it only requires a file system to hold the content
+> and the ability to create and share metadata with external systems.
+
+[coar-report]: https://www.coar-repositories.org/files/A-Case-for-Interoperability-Final-Version.pdf
+[nextgen-repos]: https://www.coar-repositories.org/files/NGR-Final-Formatted-Report-cc.pdf
+
+## Advantages for repositories and journals when harvested by CORE
+
+CORE is a global aggregator of open access articles (metadata and full texts).
+When repositories and journals harvested by CORE they enjoy the following
+benefits:
+
+1.  CORE makes research papers more discoverable. CORE significantly
+    increases the number of times repository content gets accessed round the
+    globe. A study of 21 UK institutions carried out in 2019 showed that
+    when a repository is harvested by CORE, the [number of content downloads
+    increases by 15% on average][increase-1] and up to 32% if the repository
+    is well configured for harvesting.
+
+2.  CORE ensures an [increased visibility of your content][increase-2].
+    Even though open access content may be hosted in repositories and journals
+    platforms, it is not always easily discoverable. CORE can further
+    disseminate the harvested content, increase the number of users who read
+    it and download it, and consequently increase the [output’s visibility and
+    impact][oa-discovery-impact].
+
+3.  CORE integrates and makes your content discoverable across a variety
+    of platforms including [PMC LinkOut][pmc-linkout], Microsoft Academic
+    Search and a range of library discovery services. By developing these
+    collaborations, CORE facilitates the widest possible dissemination of open
+    access content and increases the visibility of content from your
+    repository
+
+4.  CORE also increases the visibility of open access content via its
+    [Recommender service](~services/recommender), a plug-in for
+    repositories, journal systems and web interfaces, provides suggestions
+    on relevant articles to the one currently displayed. This means that
+    content from your repository can be recommended to a user while browsing
+    in another repository system. The CORE Recommender displays free to read
+    articles only that can be accessed without a paywall and it is also
+    available to thousands of users of the [CORE Discovery](~services/discovery)
+    browser extension.
+
+5.  CORE exchanges data with other services of international coverage,
+    such as Microsoft Academic Graph and [CrossRef][mucc] to enrich the
+    harvested data. As data from repositories often come without basic
+    identifiers, e.g. DOIs and ORCIDs, CORE enhances the harvested metadata,
+    creates links and consequently showcases the relationship between
+    repository outputs and published literature. The [CORE Repository
+    Dashboard](~services/repository-dashboard) is a service that assists
+    repository managers with the discovery and identification of this
+    information and speeds up the record updating in the repository. Thus,
+    CORE’s functionality complements repositories and creates a mutually
+    beneficial ecosystem.
+
+6.  CORE contributes to [plagiarism detection][turnitin-partnership], ensuring
+    that open access research outputs are not misused. This helps you to
+    ensure that the work of the affiliated to your institution academics is
+    less likely to be plagiarised.
+
+7.  CORE can technically validate and monitor your repository and help you
+    to keep it well configured. Via the [CORE Repository
+    Dashboard](~services/repository-dashboard) service and through the
+    harvesting process, CORE can detect technical issues relating to the
+    configuration of your repository or journal that affect the machine
+    accessibility and visibility of your content. CORE generates error
+    messages relating to the configuration of your platform and provides
+    fixing solutions and details, assisting repository managers and platform
+    owners with the platform’s technical improvements.
+
+8.  CORE provides analytical information to funders, organisations and
+    other stakeholders, allowing the national and international monitoring
+    of content growth, predicting new trends in scientific disciplines, etc.
+    Thanks to its vast corpus of open access content CORE is in position to
+    assist funders with identification of funder open access policy
+    compliant (or non-compliant) outputs at the level of individual
+    articles. CORE has been listed in the [REF2021 audit guidance][ref-audit]
+    as the service that will assist with the a) verification of the dates that
+    outputs became publicly available and b) compare the datePublished and
+    depositedDate.
+
+9.  CORE can provide [harmonised programmable
+    access](~services#access-to-raw-data) to all available open
+    access metadata and full text, which is needed to enable content reuse
+    by new services, possibly utilising text mining and other forms of text
+    and data analytics.
+
+[increase-1]: https://scholarlycommunications.jiscinvolve.org/wp/2020/03/19/being-an-enabling-infrastructure-core-makes-open-access-more-visible-and-reusable/
+[increase-2]: http://oro.open.ac.uk/37824/
+[pmc-linkout]: https://blog.core.ac.uk/2020/01/30/core-update-for-october-to-december-2019/#CORE_collaborations_and_negotiations
+[oa-discovery-impact]: https://www.jisc.ac.uk/guides/open-access-discovery-usage-and-impact
+[mucc]: https://scholarlycommunications.jiscinvolve.org/wp/2020/02/24/core-raises-repository-data-quality-by-consolidating-information-from-external-datasets/
+[turnitin-partnership]: https://www.turnitin.com/press/turnitin-partners-with-core
+[ref-audit]: https://www.ref.ac.uk/publications/audit-guidance-201904/

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -1,0 +1,41 @@
+---
+title: Privacy notice
+---
+
+Here is an overview about how we process personal data.
+
+This page supplements the information provided in 
+[The Open University's Privacy Notice][ou-privacy].
+
+## Measuring our visitors
+
+We collect anonymous statistics to help us improve our site using 
+[Google Analytics](https://support.google.com/analytics/answer/6004245).
+We use this data to understand how our site is used and to make it better. 
+You may also [opt out](https://tools.google.com/dlpage/gaoptout) if you wish.
+
+## Registering for our services
+
+When you register for any of our services, we may request personal information 
+from you such as your name and email address. We use this information to 
+provide the services you requested and for improving them. We may, with your 
+permission, also contact you about other services and products we think you 
+will be interested in.
+
+We will never share your personal information, such as your email address, with 
+any third party except when required for the delivery of our own services or 
+where the law requires us to do so. For example, we might need to pass your 
+information to a third party provider to process payments.
+
+## Updates to this policy
+
+We may update this policy as required by law and as technology changes. 
+We suggest you regularly check this document for the latest changes. We may 
+notify you by email of any changes to this privacy notice.
+
+## Any more questions?
+
+If you have any questions regarding our use of your data or for any other
+reason, please [contact us](~contact).
+
+[ou-privacy]: https://www.open.ac.uk/about/main/strategy-and-policies/policies-and-statements/website-privacy-ou

--- a/pages/ref-audit.md
+++ b/pages/ref-audit.md
@@ -1,0 +1,276 @@
+---
+title: CORE support for UK HEIs in the REF 2021 Open Access Audit
+---
+
+In June 2019, Research England released [REF Audit Guidance](https://www.ref.ac.uk/media/1164/ref-2019_04-audit-guidance.pdf) 
+which states that CORE data will be used in the REF 2021 Open Access Policy Audit. 
+Following the issuing of the guidance, a number of institutions approached CORE 
+asking what they can do to ensure CORE can accurately collect the required data 
+about their outputs. 
+
+The purpose of this document is to provide advice and recommendations to UK HEIs 
+with regards to exposing data to CORE through their repositories. In this document, we use the term *repository* to refer to a system that the HEI will use for the purposes of REF 2021 as defined in the Deposit requirements, paragraph 235 of the [Guidance on submissions](https://www.ref.ac.uk/media/1092/ref-2019_01-guidance-on-submissions.pdf). 
+
+### Contents of this document
+
+1. [Key REF 2021 Open Access Policy sections relevant to CORE](#oa-policy)  
+2. [What the guidance says about the use of CORE in the audit](#core-audit)  
+3. [Recommendations for exposing research outputs’ metadata to CORE in support of the audit](#recommendations)  
+4. [Why the audit should be supported by an aggregation?](#reasons)  
+5. [How will CORE collect the information?](#collect-info)  
+6. [How can CORE help you with making sure your repository is represented well?](#repo-representation)  
+7. [Subscribe to CORE Repository Edition](#repository-edition)
+
+<h2 id="oa-policy">Key REF 2021 Open Access Policy sections relevant to CORE</h2>
+
+For the next Research Excellence Framework (REF 2021), a policy has been introduced for open access. 
+The policy applies to research outputs satisfying the following two criteria:  
+
+* Outputs published in a journal or in conference proceedings with an ISSN number.  
+* Outputs accepted for publication after 1 April 2016.  
+
+The policy stipulates that to be eligible for submission to REF 2021, these
+outputs must be deposited in a repository (institutional, subject, or a
+repository service) within a specified timeframe. More specifically:  
+
+* Outputs accepted for publication from 1 April 2016 to 31 March 2018 must be
+  deposited no later than three months after the **date of publication**.
+* Outputs accepted for publication from 1 April 2018 to 31 December 2020 must be
+  deposited no later than three months after the **date of acceptance**.  
+
+For more details of the policy please see [REF Guidance on Submissions](https://www.ref.ac.uk/media/1092/ref-2019_01-guidance-on-submissions.pdf), 
+paragraphs [233 to 255](https://www.ref.ac.uk/media/1092/ref-2019_01-guidance-on-submissions.pdf#REF_Guidance%20on%20Submissions.indd%3A223%3A62).
+
+<h2 id="core-audit">What the guidance says about the use of CORE in the audit</h2>
+
+In June 2019, Research England released [REF Audit
+Guidance](https://www.ref.ac.uk/media/1164/ref-2019_04-audit-guidance.pdf) which
+describes how eligibility with the open access policy will be audited. Among
+other things, the Audit Guidance specifies that CORE data will be used in the
+audit. More specifically, it states:
+
+> 40. We will undertake verification of the dates that outputs became publicly
+> available, particularly where they were published early in the REF period or
+> are marked as 'pending' publication (for example, by obtaining a letter from
+> the publisher). This will include checking the publication year against the
+> Crossref database and against Jisc CORE. 
+
+<!-- Markdown blockquote divider -->
+> 46. We will assess each HEIs'
+> overall compliance with the REF 2021 open access policy by… iv. Using Jisc
+> CORE, comparing the **datePublished** and **depositedDate** and identifying
+> where the number of days between the two dates is greater than 92.  
+
+<!-- Markdown blockquote divider -->
+> 49. Where there is insufficient evidence to demonstrate a robust and
+> well-managed process for open access, we will identify a set of outputs from
+> each submission made by the HEI, and request further information to verify
+> whether they are compliant with the policy, or whether an exception applies.
+> Outputs may be selected randomly, or based on information in unpaywall.org or
+> Jisc CORE, or a combination of the two. We will select outputs that have been
+> returned as compliant with the policy, and/or outputs that have been returned
+> with exceptions.
+
+<h2 id="recommendations">
+  Recommendations for exposing research outputs’ metadata 
+  to CORE in support of the audit
+</h2>
+
+The following points list recommendations we make to institutional repositories
+to ensure their data is well represented in CORE. While these recommendations
+are not mandated by Research England, implementing them will both improve the
+quality of the data held by CORE to support the REF Audit as well as increase
+the discoverability and visibility of the institutions’ research outputs.  
+
+1. **Make sure that your institutional repository/ies are registered in CORE**: 
+We are constantly working towards CORE harvesting all repositories available.
+However, as repositories sometimes change their web locations, platforms or
+some institutions introduce multiple repositories, we advise institutions to
+check that their repositories are registered and listed on the CORE’s data
+[providers page](~data-providers). 
+
+2. **Adopt RIOXX as a data format**: One of the key reasons for the development
+of the [RIOXX metadata application](http://www.rioxx.net/) profile was to help
+institutions achieve compliance with the REF 2021 Open Access Policy. As of
+June 2019, more than 70 UK HEIs already support RIOXX. The application profile 
+directly supports some of the metadata fields that are important for the audit,
+such as *rioxxterms:publication_date*. While CORE can capture the data also from repositories not supporting RIOXX, supporting RIOXX  greatly reduces the complexity of the algorithm through which CORE acquires the data. The below recommendations detail which 
+information should be shared in the metadata and how this information should be
+exposed in RIOXX. We further provide an example RIOXX metadata record with all
+information needed for the REF Audit correctly set.
+
+3. **Add DOIs to records you are planning to submit to REF**: The REF 2021 OA
+policy requires outputs to be deposited  within three months of the date of
+acceptance, which will in many cases mean pre-publication, i.e. at a point when
+the DOI may not yet be known. To ensure the REF research outputs can be
+unambiguously matched to the metadata in the repository, we recommend that
+institutions ensure that DOIs (or other persistent identifiers such as PubMed
+ID, where appropriate) are added to records to be submitted to REF. This should
+be done sufficiently in advance of the audit taking place for all outputs where
+DOI has been assigned. According to RIOXX, DOI of the resource should be put in
+the *rioxxterms:version_of_record* field.
+
+4. **Release deposit dates publicly, so that they are harvestable by CORE**: At
+present, record deposit dates are not explicitly exposed by repositories in both
+RIOXX nor standard Dublin Core (DC). We are working with the RIOXX team to
+encourage explicit sharing of this information in a machine-readable form and
+will update this guidance once a solution is agreed. In the meantime, and as
+repositories store the deposit date in their  databases, we encourage
+repositories to expose the deposit date on each of the research output’s web
+page, even when RIOXX is not implemented, and ideally to mark it as “Date
+Deposited:”. For example, EPrints repositories typically display the deposit
+date on the page of a given record ([an example at Open Research
+Online](http://oro.open.ac.uk/30891/)). This date must be the date of the first
+compliant deposit. We rely on the definition of [first compliant
+deposit](http://eprintsug.github.io/hefce_oa/#date-of-first-compliant-deposit-fcd).
+
+
+5. **Ensure that dateAccepted field is used where known**: The date an output
+was accepted for publication should be shared in the RIOXX
+*dcterms:dateAccepted* field. 
+
+6. **Ensure that all records to be submitted to REF have a full text linked
+directly from the dc:identifier**: According to the RIOXX standard, the
+*dc:identifier* field **must** contain an HTTP URI which is a link directly 
+pointing to the described resource, i.e. to the MS Word, PDF or another version of
+the manuscript. This field should be populated for all records your institution
+is planning to submit to the REF and should appear exactly once in the record,
+so that the availability of the output in the repository can be automatically
+checked.
+
+7. **Ensure that your repository OAI-PMH endpoint is operational**: The OAI-PMH
+endpoint in your repository enables aggregators to collect data from your
+repository. The [Confederation of Open Access Repositories
+(COAR)](https://www.coar-repositories.org/) states that the real benefits of
+repositories come from interoperability which gives us the ability to exchange
+data within a network. This is currently realised by the OAI-PMH protocol. In
+the majority of cases, the OAI-PMH endpoint will be correctly working in your
+repository by default. To check its operation there are freely available
+[validators](http://validator.oaipmh.com/) that ensure the correct response of
+the endpoint. However, the validator does not fully ensure that the data from 
+the repository could be harvested without issues, which could be a potential
+problem, especially for larger repositories. Any repository can register freely
+for the [CORE Repository Dashboard](~services/repository-dashboard/) account
+which enables the repository to check its harvesting status.  
+
+Below is an example of a RIOXX record with all recommended fields populated:
+
+<pre>
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;?xml-stylesheet type="text/xsl" href="/rioxx2.xsl"?&gt;
+&lt;rioxx&gt;
+  xmlns="http://www.rioxx.net/schema/v2.0/rioxx/"
+  xmlns:dc="http://purl.org/dc/elements/1.1/" 
+  xmlns:dcterms="http://purl.org/dc/terms/" 
+  ...
+&gt;
+  &lt;dc:title&gt;
+    Article title
+  &lt;/dc:title&gt;
+  &lt;rioxxterms:author id="http://orcid.org/0000-1234-5678-9000"&gt;
+    Author name
+  &lt;/rioxxterms:author&gt;
+  &lt;dc:language&gt;
+    en
+  &lt;/dc:language&gt;
+  &lt;dc:publisher&gt;
+    Article publisher (In Press)
+  &lt;/dc:publisher&gt;
+  <b>&lt;dc:identifier&gt;
+    http://repository.ac.uk/12345.pdf
+  &lt;dc:identifier&gt;
+  &lt;dcterms:dateAccepted&gt;
+    2019-07-31
+  &lt;/dcterms:dateAccepted&gt;
+  &lt;rioxxterms:publication_date&gt;
+    2019-09-19
+  &lt;/rioxxterms:publication_date&gt;
+  &lt;rioxxterms:version_of_record&gt;
+    http://dx.doi.org/10.1000/abcd.1234.5678
+  &lt;/rioxxterms:version_of_record&gt;</b>
+  ...
+&lt;/rioxx&gt;
+</pre>
+
+<h2 id="reasons">Why the audit should be supported by an aggregation?</h2>
+
+
+1. **Individual HEIs have a local and incomplete view of compliance:** An output deposited late to a repository maintained by one institution can still be compliant due to a timely deposit at another repository. Research collaborations are international, i.e. the first compliant deposit can be to an overseas repository and this could also include non-institutional subject repositories, such as arXiv. While a few institutions are involved in cross-institutional checking for possible external deposit, this practice requires human labour and is limited only to cooperating institutions. Aggregators have a global and more complete view over the data and can provide technology that will effectively support institutions in better understanding which outputs are compliant and which are not even prior to the REF submission.  
+
+2. **Open Access uptake monitoring:** A key intention of the REF 2021 OA Policy is to increase the proportion of OA outputs and decrease the time lag between acceptance and deposit. As a significant proportion of web transactions for accessing research papers is to recent papers, if research becomes available earlier in repositories than on publisher platforms and is, in addition, available without a paywall, this will a) significantly increase the importance of the repository infrastructure, b) accelerate research dissemination by making the scholarly communication process more efficient and c) provide better value to citizens. Citing Lord Kelvin's “If you cannot measure it, you can not improve it,” it is crucial, for any policy, that its uptake can be monitored and improvements measured at any time. By capturing this information at an aggregation level, we are enabling precisely that. For example, if institutions were to delivere deposit dates to Research England as a one-off in csv only at the time of REF submission, this would not allow such monitoring, as it would only provide deposit dates for a small  subsample of content in repositories and only at one point in time. It is is crucial to realise that the importance of the REF 2021 OA policy goes far beyond REF. The practice of depositing early should prevail beyond the REF submission date in 2020 as  we should be able to monitor our journey to not just open access but also to fast open access. In the future, similar policies (e.g. due to Plan S) will require similar monitoring, so it makes sense to get ready now. 
+
+3. **Audit transparency:** Exposing deposit dates and other important information in a machine readable format in support of the audit through repositories ensures transparency of the audited data. Everyone can check the data that not only gets submitted but also that is about to get submitted, ensuring good preparation leading to no surprises. Overall, transparency is a key to good research practices and open science. It also often leads to more attention resulting in improvement of processes and better quality data. 
+
+4. **Efficiency:** Collecting data for the audit through an aggregation is by far the most efficient method of assembling the data. Where systems are already in place, it does not require any manual work or action. Any work likely to be conducted improves the repository infrastructure for beyond REF 2021 resulting in a positive change across the sector. As it is expected that similar audits might need to be carried out in the future, it is sensible to automate this process now. 
+
+5. **Verifiability:** Assembling data at an aggregation level offers verifiability of the declared data. While this hasn’t been implemented so far, it will be possible to test both the presence and machine availability of the full text, which is key to many use cases, including text and data mining. Exposing data, such as deposit dates, will also be seen as a positive development by publishers. From the perspective of CORE, our intention to test these points is motivated purely by our strive to feedback any issues back to repositories and support them in creating a better and more interoperable repository infrastructure, which we all deserve. 
+
+<h2 id="collect-info">How will CORE collect the information?</h2>
+
+CORE regularly harvests data from repositories. If all the recommendations
+described above are followed, then the procedure is straightforward. If any
+deviations are present, CORE will try to collect the data in alternative ways. 
+These include:
+
+* If RIOXX is not supported, CORE will gather metadata, such as information
+  about the identifier and DOIs, using standard DC. 
+
+* If DOIs are not available for some records, CORE will use available metadata
+  to match these records against several key databases, including Crossref and
+  Microsoft Academic Graph (MAG), to discover the DOIs. 
+
+* If the date of publication is not supplied by the repository or it doesn’t
+  have the desired granularity (we prefer ISO 8601 (post–2004 versions) which
+  follows the following format: YYYY-MM-DD), CORE will collect the publication
+  date from Crossref. Where the publication date is supplied by the repository
+  but the date is not the same as in Crossref, the decision as to which one 
+  will be used in the audit will be up to the discretion of Research England. 
+
+* As deposit dates are not part of standard DC and not yet part of RIOXX, CORE
+  therefore implements the following two methods for collecting them: 
+
+  * Where deposit dates are visible through the web pages in the repository 
+    (see Item 4 above), CORE attempts to collect them by scraping them, 
+    i.e. extracting the data from the web page of the record, using custom 
+    built scrapers for a variety of repository platforms. 
+
+  * Where deposit dates cannot be obtained using scraping, CORE makes
+    use of the record’s Datestamp provided in the record’s metadata. This
+    is done in the following way. CORE stores the first Datestamp it
+    receives for a given record, i.e. the first time CORE harvests the
+    record, as the deposit date. Subsequent changes to the Datestamp, which
+    could be due to the record’s updates, will not affect the deposit date.
+    Due to the frequent harvesting, this provides a close estimation of the
+    deposit date.
+
+This describes the method we use to collect data from repositories that
+currently do not support RIOXX. We might update this method if we identify a
+way of improving it, such as to make the data we collect more accurate.
+
+When on rare occassions the collected data might be incomplete, it will be up to the discretion of Research England perfroming the audit to interpret the data. We believe that if a record present in the repository has not been harvested by CORE or it was not possible to capture some metadata, this should not negatively affect the audit result. To this end, our aim is to support institutions to identify and resolve any issues prior to the audit. 
+
+<h2 id="repo-representation">
+  How can CORE help you with making sure your repository is represented well?
+</h2>
+
+CORE Repository Dashboard already provides useful information to check that your
+repository is being properly harvested. Additionally, we have released a brand new version of the CORE Repository Dashboard, from which the deposit dates can be retrieved and we will release it soon. We also offer a free 
+[CORE Discovery](~services/discovery) repository plugin which can help repositories discover Open Access full text versions of articles for metadata records in repositories which do not have a full text manuscript attached.
+
+To answer further questions, we have also established and maintain an [FAQ
+section](~faq#ref-audit) for the purposes of the audit. If you have
+any further questions, please [contact](~contact) the CORE team for support and
+we will be happy to help.
+
+<h2 id="repository-edition">
+  Subscribe to CORE Repository Edition
+</h2>
+
+The new [CORE Repository Edition](~services/repository-edition) has now been
+launched. This new edition contains both new tools for data enrichments and to
+enable repositories to help ensure compliance with the REF 2021 Open Access
+Policy. 
+ 
+Visit the [CORE Repository Edition](~services/repository-edition) service for
+further details. To subscribe contact us via email at
+[&#115;&#97;&#108;&#101;&#115;&#64;&#99;&#111;&#114;&#101;&#46;&#97;&#99;&#46;&#117;&#107;](mailto:%73%61l%65s%40%63o%72%65%2ea%63%2eu%6b).

--- a/pages/terms.md
+++ b/pages/terms.md
@@ -1,0 +1,118 @@
+---
+title: Terms & Conditions
+---
+
+<style>
+  ol p + ol, ol p + ul, ul p + ol, ul p + ul {
+    margin-bottom: 1.5rem;
+  }
+
+  .content h2 {
+    margin-top: 3rem;
+  }
+</style>
+
+This page sets the Terms & Conditions under which
+[CORE data<sup>*</sup>](#disclaimer "Read more about data") can
+be used by others.
+
+## CC-BY licenced datasets
+
+1.  You can use these datasets for any commercial or non-commercial
+    purposes in line with the&nbsp;CC-BY licence.
+
+2.  You need to acknowledge the use of CORE as [described](/acknowledge).
+
+
+## Other datasets and the API
+
+While you need to obtain a licence to use other CORE datasets as well as the CORE API, many of our users are eligible for a free licence.
+
+However, you should contact us, irrespective of any potential free licence
+eligibility as described below, if you are developing or intending to develop
+a product, service or software using CORE data which:
+
+1.  might be monetised now or in the future <b>OR</b>
+2.  is expected to serve only a restricted group of
+    beneficiaries&nbsp;(e.g.&nbsp;only your own organisation) <b>OR</b>
+3.  is intended for the benefit of everyone but related to the functionality
+    provided by one of CORE’s existing services, such as but not limited to
+    an API, a recommender system, search, discovery system
+    or analytical dashboard.
+
+
+### Free licence eligibility
+
+If your use of CORE data does not fall under any of the categories mentioned
+in the above points&nbsp;1-3&nbsp;<b>AND</b> you are either an individual
+or a public research organisation, then you might be eligible for
+a free licence.
+
+
+#### Individuals
+
+If you are an individual, you can use CORE data freely if:
+
+1.  You are conducting work in your own personal
+    capacity <b>AND</b>
+<!--
+    2.  You will comply with our Terms and Conditions
+        for free use <b>AND</b>
+-->
+3.  You will acknowledge the use of CORE as [described](/acknowledge).
+
+
+#### Public research organisations
+
+If you are working for a public research
+organisation&nbsp;(e.g.&nbsp;a&nbsp;university):
+
+1.  You can use CORE data freely if:
+
+    - You are pursuing research on CORE data with
+      the objective of producing a research paper or
+      a publicly available report <b>AND</b>
+    <!--
+        - You will comply with our Terms and Conditions
+          for free use <b>AND</b>
+    -->
+    - You will acknowledge the use of CORE as [described](/acknowledge).
+
+2.  If you are intending to use CORE as part of
+    a research project(s) then you should 
+    [contact us](mailto:th%65%74eam%40c%6fr%65%2eac%2eu%6b)
+    to obtain a licence. Depending on the circumstances, we will assess
+    if you are eligible for a free licence. 
+
+### Authorisation of use
+
+You authorise us to use the logo of your organisation and/or project on our
+website and mentioning our support to you.
+
+We reserve the right to withdraw our approval for use of CORE data at any time
+by giving you a 30-day notice.
+
+<section id="disclaimer">
+
+## Disclaimer
+
+The term **CORE data** refers to a database created by harvesting and
+processing information publicly available on the Internet. Every effort has
+been made to ensure this dataset contains open access content only. We have
+included content only from repositories and journals that are listed in
+registries where the condition for inclusion is the provision of content
+under an open access compatible license. However, as metadata are often
+inconsistent, license information is often not machine readable and, from
+time to time, repositories leak information that is not open access, we
+cannot take any responsibility for the licences of the individual content in
+the dataset. It is therefore up to the user of this dataset to ensure that
+the way in which they use the dataset does not breach copyright of any third
+party. The dataset is in no way intended for the purposes of reading the
+original publications, but for machine processing only.
+
+Additionally, while CORE retains no copyright in any of the works in the
+database, we reserve the sui generis database rights. This is due to the
+substantial investment in obtaining, processing and serving the aggregated
+data to the relevant communities of interest.
+
+</section>


### PR DESCRIPTION
Migrates the current pages of pure markdown pages from About to Content (here). Needed for oacore/about#392