### PR TITLE
Revise privacy policy with comprehensive details

### DIFF
--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -2,38 +2,105 @@
 title: Privacy notice
 description: CORE Privacy Notice
 ---
-Here is an overview about how we process personal data.
 
-This page supplements the information provided in 
-[The Open University's Privacy Notice](https://www.open.ac.uk/about/main/strategy-and-policies/policies-and-statements/website-privacy-ou).
+# Privacy Policy
 
-## Measuring our visitors
+**Last updated:** [DATE HERE]
 
-We collect anonymous statistics to help us improve our site using 
-[Google Analytics](https://support.google.com/analytics/answer/6004245).
-We use this data to understand how our site is used and to make it better. 
-You may also [opt-out](https://tools.google.com/dlpage/gaoptout) if you wish.
+This policy explains how CORE ("we", "us", "our") collects, uses, and protects information about people who use our open access research platform, including researchers, institutional partners, and members of the public who search or browse our content.
 
-## Registering for our services
+## 1. Who we are
 
-When you register for any of our services, we may request personal information 
-from you such as your name and email address. We use this information to 
-provide the services you requested and for improving them. We may, with your 
-permission, also contact you about other services and products we think you 
-will be interested in.
+CORE operates an open access research service that aggregates, indexes, and provides access to scholarly outputs (such as articles, theses, and technical reports) harvested from repositories and publishers around the world. We act as the data controller for the personal data described in this policy.
 
-We will never share your personal information, such as your email address, with 
-any third party except when required for the delivery of our own services or 
-where the law requires us to do so. For example, we might need to pass your 
-information to a third party provider to process payments.
+If you have questions about this policy or how we handle your data, you can [contact us](~contact).
 
-## Updates to this policy
+## 2. What information we collect
 
-We may update this policy as required by law and as technology changes. 
-We suggest you regularly check this document for the latest changes. We may 
-notify you by email of any changes to this privacy notice.
+### 2.1 Information you give us directly
+- **Account details** — if you register for an account (either for the Dashboard for Members or for our data services such as API and Dataset), we collect your name, email address, institutional affiliation (where provided), and, in the specific case of the CORE Membership, a password (stored in encrypted form).
+- **Correspondence** — records of any support requests, feedback, or other messages you send us.
 
-## Any more questions?
+### 2.2 Information we collect automatically
+- **Usage data** — pages visited, searches performed, documents viewed or downloaded, and general navigation patterns on the site.
+- **Device and technical data** — IP address, browser type, operating system, and referring URLs.
+- **Cookies and similar technologies** — see Section 5 below.
 
-If you have any questions regarding our use of your data or for any other
-reason, please [contact us](~contact).
+### 2.3 Information from third parties
+
+We aggregate metadata about research outputs from partner repositories, institutions, publishers and other services.  This is generally not personal data about you as a user, but where an output includes author names or affiliations, that information may appear in search results. This metadata originates from, and remains the responsibility of, the source repository or publisher. We do not create, verify, or independently maintain it. If you believe metadata associated with an output is inaccurate, outdated, or harmful, please contact the source repository directly, as they are best placed to correct or remove it. You can also ask for direct removal from the data we collect with the [Article Update / Takedown Request form](~outputs/update).
+
+## 3. How we use your information
+
+We use the information we collect to:
+
+- create and manage your account;
+- provide, maintain, and improve the search and discovery service;
+- monitor and analyse usage trends to improve site performance and content coverage;
+- communicate with you about your account, service updates, or in response to enquiries;
+- detect, investigate, and prevent misuse, fraud, or security incidents;
+- comply with legal obligations.
+
+## 4. Legal basis for processing
+
+Where UK/EU data protection law applies, we rely on the following legal bases:
+
+- **Contract**: to provide services you've signed up for (e.g. maintaining your account).
+- **Legitimate interests**: to operate, secure, and improve the service, and to understand how it is used.
+- **Consent**: for optional cookies and marketing communications, which you can withdraw at any time.
+- **Legal obligation**: where we are required to retain or disclose information by law.
+
+## 5. Cookies and analytics
+
+We use cookies and similar technologies to:
+
+- keep you signed in and remember your settings (**essential**);
+- understand how visitors use the service, using aggregated analytics data (**analytics**);
+- measure the performance of any outreach or communications about the service (**marketing**, where applicable).
+
+You can control non-essential cookies through the cookie banner shown when you first visit the site, or through your browser settings. Blocking essential cookies may affect how the service works. We collect statistics using [Google Analytics](https://support.google.com/analytics/answer/6004245). You may also [opt-out](https://tools.google.com/dlpage/gaoptout) if you wish.
+
+We may use third-party analytics providers to help us understand usage patterns. These providers process data on our behalf and are contractually restricted from using it for their own purposes.
+
+
+## 6. Sharing your information
+
+We do not sell personal data. We may share information:
+
+- with service providers who help us run the platform (e.g. hosting, analytics, email delivery), under contracts that require them to protect your data;
+- with partner repositories or institutions, where necessary to resolve metadata or access issues;
+- where required by law, regulation, or a valid legal process;
+- in connection with a merger, acquisition, or reorganisation of our service, subject to this policy continuing to apply.
+
+## 7. International transfers
+
+Because our service aggregates content from repositories worldwide, some processing may take place outside your country of residence. Where we transfer personal data internationally, we use appropriate safeguards, such as standard contractual clauses, to protect it.
+
+## 8. How long we keep your information
+
+We retain account information for as long as your account is active, and for a reasonable period afterwards to comply with legal obligations, resolve disputes, and enforce our agreements. Usage and analytics data is generally retained in aggregated or anonymised form after a limited retention period.
+
+## 9. Your rights
+
+Depending on where you live, you may have the right to:
+
+- access the personal data we hold about you;
+- request correction of inaccurate data;
+- request deletion of your data;
+- object to or restrict certain processing;
+- request a copy of your data in a portable format;
+- withdraw consent where processing is based on consent.
+
+To exercise any of these rights, [contact us](~contact). You also have the right to lodge a complaint with your local data protection authority.
+
+## 10. Children's privacy
+
+Our service is intended for researchers, students, and members of the public with a general interest in scholarly content, and is not directed at children. We do not knowingly collect personal data from children under 13.
+
+## 11. Changes to this policy
+
+We may update this policy from time to time to reflect changes in our practices or for legal reasons. We will post the updated version here with a revised "Last updated" date, and where changes are significant, we will provide additional notice.
+
+## 12. Any more questions?
+
+If you have questions, concerns, or requests relating to this policy, please [contact us](~contact)

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -79,7 +79,7 @@ We may share information:
 
 ## 7. International transfers
 
-Because our service indexs content from repositories worldwide, some processing may take place outside your country of residence. Where we transfer personal data internationally, we use appropriate safeguards, such as standard contractual clauses, to protect it.
+Because our service indexes content from repositories worldwide, some processing may take place outside your country of residence. Where we transfer personal data internationally, we use appropriate safeguards, such as standard contractual clauses, to protect it.
 
 ## 8. How long we keep your information
 

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -11,7 +11,7 @@ This policy explains how CORE ("we", "us", "our") collects, uses, and protects i
 
 ## 1. Who we are
 
-CORE operates an open access research service that aggregates, indexes, and provides access to scholarly outputs (such as articles, theses, and technical reports) harvested from repositories and publishers around the world. We act as the data controller for the personal data described in this policy.
+CORE operates an open access research service that indexes, and provides access to scholarly outputs (such as articles, theses, and technical reports) harvested from repositories and publishers around the world. We act as the data controller for the personal data described in this policy.
 
 If you have questions about this policy or how we handle your data, you can [contact us](~contact).
 
@@ -27,8 +27,8 @@ If you have questions about this policy or how we handle your data, you can [con
 - **Cookies and similar technologies** — see Section 5 below.
 
 ### 2.3 Information from third parties
+We index metadata about research outputs from partner repositories, institutions, publishers and other services. This is generally not personal data about you as a user, but where an output includes author names or affiliations, that information may appear in search results. We store and process this metadata on the basis of our legitimate interest in operating an open access discovery service — see Section 4 for more on how we rely on this basis. This metadata originates from, and remains the responsibility of, the source repository or publisher. We do not create it or verify it. If you believe metadata associated with an output is inaccurate, outdated, or harmful, please contact the source repository directly, as they are best placed to correct or remove it, our records are updated when we next index from the source. In any case, you can also request direct removal from the data we collect using the [Article Update / Takedown Request form](~outputs/update).
 
-We aggregate metadata about research outputs from partner repositories, institutions, publishers and other services.  This is generally not personal data about you as a user, but where an output includes author names or affiliations, that information may appear in search results. This metadata originates from, and remains the responsibility of, the source repository or publisher. We do not create, verify, or independently maintain it. If you believe metadata associated with an output is inaccurate, outdated, or harmful, please contact the source repository directly, as they are best placed to correct or remove it. You can also ask for direct removal from the data we collect with the [Article Update / Takedown Request form](~outputs/update).
 
 ## 3. How we use your information
 
@@ -46,16 +46,18 @@ We use the information we collect to:
 Where UK/EU data protection law applies, we rely on the following legal bases:
 
 - **Contract**: to provide services you've signed up for (e.g. maintaining your account).
-- **Legitimate interests**: to operate, secure, and improve the service, and to understand how it is used.
+- **Legitimate interests**: to operate, secure, and improve the service, and to understand how it is used. In particular, we rely on legitimate interests to index and store metadata harvested from partner repositories, institutions, and publishers (including author names or affiliations where present), in order to provide an open access discovery service. We consider this processing to be proportionate and within the reasonable expectations of researchers and institutions who make this metadata openly available for research. We balance this interest against individuals' rights by being transparent about how this metadata is sourced and used, and by offering the removal process described in Section 2.3.
 - **Consent**: for optional cookies and marketing communications, which you can withdraw at any time.
 - **Legal obligation**: where we are required to retain or disclose information by law.
+
+
 
 ## 5. Cookies and analytics
 
 We use cookies and similar technologies to:
 
 - keep you signed in and remember your settings (**essential**);
-- understand how visitors use the service, using aggregated analytics data (**analytics**);
+- understand how visitors use the service, using indexd analytics data (**analytics**);
 - measure the performance of any outreach or communications about the service (**marketing**, where applicable).
 
 You can control non-essential cookies through the cookie banner shown when you first visit the site, or through your browser settings. Blocking essential cookies may affect how the service works. We collect statistics using [Google Analytics](https://support.google.com/analytics/answer/6004245). You may also [opt-out](https://tools.google.com/dlpage/gaoptout) if you wish.
@@ -65,20 +67,23 @@ We may use third-party analytics providers to help us understand usage patterns.
 
 ## 6. Sharing your information
 
-We do not sell personal data. We may share information:
+We do not sell personal data relating to your use of the service, as a registered user or as an account holder (e.g. your name, email address, or usage data). 
+
+We may share information:
 
 - with service providers who help us run the platform (e.g. hosting, analytics, email delivery), under contracts that require them to protect your data;
 - with partner repositories or institutions, where necessary to resolve metadata or access issues;
+- through our API and datasets (both public and paid-access), which provide access to research output metadata — including, where present, author names and affiliations sourced from partner repositories and publishers as described in Section 2.3 — but do not include personal data about you as a user or account holder;
 - where required by law, regulation, or a valid legal process;
 - in connection with a merger, acquisition, or reorganisation of our service, subject to this policy continuing to apply.
 
 ## 7. International transfers
 
-Because our service aggregates content from repositories worldwide, some processing may take place outside your country of residence. Where we transfer personal data internationally, we use appropriate safeguards, such as standard contractual clauses, to protect it.
+Because our service indexs content from repositories worldwide, some processing may take place outside your country of residence. Where we transfer personal data internationally, we use appropriate safeguards, such as standard contractual clauses, to protect it.
 
 ## 8. How long we keep your information
 
-We retain account information for as long as your account is active, and for a reasonable period afterwards to comply with legal obligations, resolve disputes, and enforce our agreements. Usage and analytics data is generally retained in aggregated or anonymised form after a limited retention period.
+We retain account information for as long as your account is active, and for a reasonable period afterwards to comply with legal obligations, resolve disputes, and enforce our agreements. Usage and analytics data is generally retained in indexd or anonymised form after a limited retention period.
 
 ## 9. Your rights
 
@@ -95,7 +100,8 @@ To exercise any of these rights, [contact us](~contact). You also have the right
 
 ## 10. Children's privacy
 
-Our service is intended for researchers, students, and members of the public with a general interest in scholarly content, and is not directed at children. We do not knowingly collect personal data from children under 13.
+Our service, including its API and datasets, is openly accessible and may be used by anyone, including students of any age, for research, learning, or educational purposes. However, account registration is not directed at children, and we do not knowingly collect personal data (such as name or email address) from children under 13 through account creation. If you believe a child has provided personal data to us by registering an account, please [contact us](~contact) and we will take steps to delete it.
+In rare cases, metadata harvested from partner repositories (as described in Section 2.3) may include personal data relating to a child — for example, where a minor is named as an author or contributor. As with other third-party metadata, we do not create or verify this data, and responsibility for its accuracy rests with the source repository. If you are a parent, guardian, or the individual concerned and would like such data removed from our index, you can use the [Article Update / Takedown Request form](~outputs/update), and we will treat such requests as a priority.
 
 ## 11. Changes to this policy
 

--- a/pages/privacy.md
+++ b/pages/privacy.md
@@ -57,7 +57,7 @@ Where UK/EU data protection law applies, we rely on the following legal bases:
 We use cookies and similar technologies to:
 
 - keep you signed in and remember your settings (**essential**);
-- understand how visitors use the service, using indexd analytics data (**analytics**);
+- understand how visitors use the service, using aggregated analytics data (**analytics**);
 - measure the performance of any outreach or communications about the service (**marketing**, where applicable).
 
 You can control non-essential cookies through the cookie banner shown when you first visit the site, or through your browser settings. Blocking essential cookies may affect how the service works. We collect statistics using [Google Analytics](https://support.google.com/analytics/answer/6004245). You may also [opt-out](https://tools.google.com/dlpage/gaoptout) if you wish.
@@ -83,7 +83,7 @@ Because our service indexs content from repositories worldwide, some processing 
 
 ## 8. How long we keep your information
 
-We retain account information for as long as your account is active, and for a reasonable period afterwards to comply with legal obligations, resolve disputes, and enforce our agreements. Usage and analytics data is generally retained in indexd or anonymised form after a limited retention period.
+We retain account information for as long as your account is active, and for a reasonable period afterwards to comply with legal obligations, resolve disputes, and enforce our agreements. Usage and analytics data is generally retained in aggregated or anonymised form after a limited retention period.
 
 ## 9. Your rights
 


### PR DESCRIPTION
Expanded the privacy policy to include detailed sections on data collection, usage, and user rights, removing connections with the Open University.